### PR TITLE
Clone frontend repos at runtime & extract JSON keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+git2 = "0.20"
 regex = "1"
 serde_json = "1"
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
-# Linguist
+# Linguist - Repository Key Extraction Tool
 
-Linguist checks language files to verify consistency and integrity.
+## Usage
+
+### Cloning Repositories with SSH Authentication
+
+To run `linguist`, you must specify the **path to your SSH private key** as an argument.
+
+```sh
+cargo run ~/.ssh/my_custom_rsa_key
+```
+
+### Prerequisites
+
+Before running `linguist`, make sure:
+
+* You have GitHub SSH authentication set up.
+* Your SSH key is added to GitHub.
+
+  Run the following command to test SSH authentication
+
+  ```sh
+  ssh -T git@github.com
+  ```
+
+  If you see:
+  _"Hi `<your-username>`! You've successfully authenticated.."_
+
+  **Then SSH is working correctly.**
+
+* Your SSH key is added to `ssh-agent`:
+
+  ```sh
+  eval "$(ssh-agent -s)"
+  ssh-add ~/.ssh/my_custom_rsa_key
+  ```
+
+  If authentication issues persist, rerun this command again.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,0 +1,101 @@
+use std::env;
+use std::io::{self, Error, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use git2::{build::RepoBuilder, Cred, FetchOptions, RemoteCallbacks};
+use tempfile::TempDir;
+
+pub struct RepoManager {
+    pub temp_dir: TempDir,
+}
+
+impl RepoManager {
+    pub fn new() -> Result<Self, io::Error> {
+        TempDir::new()
+            .map(|temp_dir| Self { temp_dir })
+            .map_err(|_| Error::new(ErrorKind::Other, "Failed to create temp dir"))
+    }
+
+    pub fn clone_repo(&self, repo_url: &str, dest_name: &str) -> Result<PathBuf, git2::Error> {
+        let dest_path = self.temp_dir.path().join(dest_name);
+
+        let mut callbacks = RemoteCallbacks::new();
+        let mut attempted = false;
+
+        callbacks.credentials(move |_url, username_from_url, _allowed_types| {
+            if attempted {
+                return Err(git2::Error::from_str("❌ SSH authentication failed"));
+            }
+            attempted = true;
+
+            match username_from_url {
+                Some(username) => Cred::ssh_key_from_agent(username),
+                None => Err(git2::Error::from_str(
+                    "❌ Username for SSH authentication is missing",
+                )),
+            }
+        });
+
+        let mut fetch_options = FetchOptions::new();
+        fetch_options.remote_callbacks(callbacks);
+
+        let mut builder = RepoBuilder::new();
+        builder.fetch_options(fetch_options);
+
+        match builder.clone(repo_url, &dest_path) {
+            Ok(_) => {
+                println!("✅ Successfully cloned {repo_url}");
+                Ok(dest_path)
+            }
+            Err(_) => Err(git2::Error::from_str("❌ Failed to clone repository.")),
+        }
+    }
+}
+
+pub fn setup_ssh_agent(ssh_key_path: &Path) -> Result<(), git2::Error> {
+    if env::var("SSH_AUTH_SOCK").is_err() {
+        let output = Command::new("ssh-agent")
+            .stdout(Stdio::piped())
+            .output()
+            .map_err(|_| git2::Error::from_str("Failed to start ssh-agent"))?;
+
+        let output_str = String::from_utf8_lossy(&output.stdout);
+        for line in output_str.lines() {
+            if let Some((key, value)) = line.split_once('=') {
+                if key == "SSH_AUTH_SOCK" || key == "SSH_AGENT_PID" {
+                    let value = value.trim_end_matches(';');
+                    env::set_var(key, value);
+                }
+            }
+        }
+    }
+
+    if !ssh_key_path.exists() {
+        return Err(git2::Error::from_str(
+            "SSH key not found at the specified path.",
+        ));
+    }
+
+    let ssh_add_output = Command::new("ssh-add")
+        .arg(ssh_key_path)
+        .output()
+        .map_err(|_| git2::Error::from_str("Failed to run ssh-add"))?;
+
+    if !ssh_add_output.status.success() {
+        return Err(git2::Error::from_str("Failed to add SSH key to agent."));
+    }
+
+    let ssh_test = Command::new("ssh")
+        .arg("-T")
+        .arg("git@github.com")
+        .output()
+        .map_err(|_| git2::Error::from_str("Failed to execute SSH command"))?;
+
+    let ssh_error = String::from_utf8_lossy(&ssh_test.stderr);
+    if ssh_error.contains("successfully authenticated") {
+        return Ok(());
+    }
+
+    Err(git2::Error::from_str("❌ SSH authentication test failed."))
+}


### PR DESCRIPTION
Closes #8
- Clone `frontary` and UI repositories at runtime using `git2`.
- Store cloned repositories in a temporary directory.
- Extract and save JSON keys from cloned repositories.