### PR TITLE
Support passphrase-protected SSH keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Compared `all_strings` against the keys in ko-KR.json and en-US.json.
 - Added optional CLI flags `--ui-path <PATH>` and `--frontary-path <PATH>` to
   allow using local copies of the UI and Frontary repositories.
+- Supported passphrase-protected SSH keys by reading the `SSH_PASSPHRASE`
+  environment variable and passing it into Git2’s `Cred::ssh_key` instead of requiring
+  a manual `ssh-add`.

--- a/README.md
+++ b/README.md
@@ -18,26 +18,21 @@ that they remain accurate and complete.
 Before running `linguist`, make sure:
 
 - You have GitHub SSH authentication set up.
-- Your SSH key is added to GitHub.
+- **If your SSH private key _is_ passphrase-protected**, You can set the
+  passphrase via an environment variable and let `linguist` use it automatically:
 
-  Run the following command to test SSH authentication
+  ```sh
+  export SSH_PASSPHRASE="your_passphrase_here"
+  ```
+
+- **Always** verify basic SSH connectivity once (only needed if you’re troubleshooting):
 
   ```sh
   ssh -T git@github.com
   ```
 
-  If you see: _"Hi `<your-username>`! You've successfully authenticated.."_
-
-  **Then SSH is working correctly.**
-
-- Your SSH key is added to `ssh-agent`:
-
-  ```sh
-  eval "$(ssh-agent -s)"
-  ssh-add ~/.ssh/my_custom_rsa_key
-  ```
-
-  If authentication issues persist, rerun this command again.
+  You should see:
+  > Hi `<your-username>`! You've successfully authenticated...
 
 ## Usage
 


### PR DESCRIPTION
Closes #24
- Read the passphrase from the SSH_KEY_PASSPHRASE environment variable and pass it into `git2::Cred::ssh_key`
- Simplify `setup_ssh_agent` to only validate the key and set `SSH_KEY_PATH`
- Update `RepoManager::clone_repo` to use `Cred::ssh_key` instead of invoking ssh-add.