### PR TITLE
Enforce Clippy lint against `unwrap`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check --config group_imports=StdExternalCrate
       - name: Clippy
-        run: cargo clippy -- -D warnings -W clippy::pedantic
+        run: cargo clippy -- -D warnings
       - name: Check
         run: cargo check --examples
       - name: markdownlint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ git2 = "0.20"
 regex = "1"
 serde_json = "1"
 tempfile = "3"
+
+[lints.clippy]
+pedantic = "warn"
+unwrap_used = "warn"


### PR DESCRIPTION
Closes #36
- Set `unwrap_used = "warn"` in Cargo.toml
- Allowed `unwrap` in tests via `.clippy.toml`
- Added `pedantic = "warn"` for additional linting coverage